### PR TITLE
be: return EINVAL for epoch +>1

### DIFF
--- a/src/storage/ceph/cls_zlog.h
+++ b/src/storage/ceph/cls_zlog.h
@@ -224,9 +224,12 @@ class HeadObject {
   }
 
   int set_epoch(uint64_t epoch) {
-    if (epoch == (hdr_.epoch() + 1)) {
+    const uint64_t required_epoch = hdr_.epoch() + 1;
+    if (epoch == required_epoch) {
       hdr_.set_epoch(epoch);
       return 0;
+    } else if (epoch > required_epoch) {
+      return -EINVAL;
     }
     return -ESPIPE;
   }

--- a/src/storage/ceph/test_cls_zlog.cc
+++ b/src/storage/ceph/test_cls_zlog.cc
@@ -1057,7 +1057,7 @@ TEST_F(ClsZlogTest, CreateView_InitWithEpochOne) {
   ret = view_create(0, bl);
   ASSERT_EQ(ret, -EINVAL);
   ret = view_create(2, bl);
-  ASSERT_EQ(ret, -ESPIPE);
+  ASSERT_EQ(ret, -EINVAL);
 
   // first epoch = 1
   ret = view_create(1, bl);
@@ -1074,7 +1074,7 @@ TEST_F(ClsZlogTest, CreateView_StrictOrdering) {
   ret = view_create(0, bl);
   ASSERT_EQ(ret, -EINVAL);
   ret = view_create(2, bl);
-  ASSERT_EQ(ret, -ESPIPE);
+  ASSERT_EQ(ret, -EINVAL);
 
   // first epoch = 1
   ret = view_create(1, bl);
@@ -1085,9 +1085,9 @@ TEST_F(ClsZlogTest, CreateView_StrictOrdering) {
   ret = view_create(1, bl);
   ASSERT_EQ(ret, -ESPIPE);
   ret = view_create(4, bl);
-  ASSERT_EQ(ret, -ESPIPE);
+  ASSERT_EQ(ret, -EINVAL);
   ret = view_create(5, bl);
-  ASSERT_EQ(ret, -ESPIPE);
+  ASSERT_EQ(ret, -EINVAL);
   ret = view_create(0, bl);
   ASSERT_EQ(ret, -EINVAL);
 
@@ -1110,6 +1110,13 @@ TEST_F(ClsZlogTest, CreateView_StrictOrdering) {
   ASSERT_EQ(ret, -ESPIPE);
   ret = view_create(4, bl);
   ASSERT_EQ(ret, -ESPIPE);
+  ret = view_create(5, bl);
+  ASSERT_EQ(ret, -ESPIPE);
+  ret = view_create(7, bl);
+  ASSERT_EQ(ret, -EINVAL);
+
+  ret = view_create(6, bl);
+  ASSERT_EQ(ret, 0);
 }
 
 TEST_F(ClsZlogTest, ReadView_BadInput) {

--- a/src/storage/lmdb/lmdb.cc
+++ b/src/storage/lmdb/lmdb.cc
@@ -271,6 +271,10 @@ int LMDBBackend::ProposeView(const std::string& hoid,
   assert(val.mv_size == sizeof(*proj_obj));
 
   const auto required_epoch = proj_obj->epoch + 1;
+  if (epoch > required_epoch) {
+    txn.Abort();
+    return -EINVAL;
+  }
   if (epoch != required_epoch) {
     txn.Abort();
     return -ESPIPE;

--- a/src/storage/ram/ram.cc
+++ b/src/storage/ram/ram.cc
@@ -192,6 +192,9 @@ int RAMBackend::ProposeView(const std::string& hoid,
 
   ProjectionObject& proj_obj = boost::get<ProjectionObject>(it->second);
   const auto required_epoch = proj_obj.epoch + 1;
+  if (epoch > required_epoch) {
+    return -EINVAL;
+  }
   if (epoch != required_epoch) {
     return -ESPIPE;
   }

--- a/src/storage/test_backend.cc
+++ b/src/storage/test_backend.cc
@@ -3,8 +3,6 @@
 #include <map>
 #include <set>
 
-// CHECK epoch=0 is eninval not espipe...
-
 TEST_F(BackendTest, DeleteBeforeInit) {
   auto no_init_be = create_minimal_backend();
   no_init_be.reset();
@@ -122,12 +120,14 @@ TEST_F(BackendTest, ProposeView_Epoch) {
   ASSERT_EQ(backend->ProposeView(hoid, 1, ""), -ESPIPE);
   ASSERT_EQ(backend->ProposeView(hoid, 2, ""), 0);
   ASSERT_EQ(backend->ProposeView(hoid, 3, ""), 0);
-  ASSERT_EQ(backend->ProposeView(hoid, 5, ""), -ESPIPE);
-  ASSERT_EQ(backend->ProposeView(hoid, 6, ""), -ESPIPE);
-  ASSERT_EQ(backend->ProposeView(hoid, 6000, ""), -ESPIPE);
-  ASSERT_EQ(backend->ProposeView(hoid, 5, ""), -ESPIPE);
+  ASSERT_EQ(backend->ProposeView(hoid, 5, ""), -EINVAL);
+  ASSERT_EQ(backend->ProposeView(hoid, 6, ""), -EINVAL);
+  ASSERT_EQ(backend->ProposeView(hoid, 3, ""), -ESPIPE);
+  ASSERT_EQ(backend->ProposeView(hoid, 6000, ""), -EINVAL);
+  ASSERT_EQ(backend->ProposeView(hoid, 5, ""), -EINVAL);
   ASSERT_EQ(backend->ProposeView(hoid, 4, ""), 0);
   ASSERT_EQ(backend->ProposeView(hoid, 2, ""), -ESPIPE);
+  ASSERT_EQ(backend->ProposeView(hoid, 3, ""), -ESPIPE);
   ASSERT_EQ(backend->ProposeView(hoid, 1, ""), -ESPIPE);
 
   ASSERT_EQ(backend->CreateLog("b", "", &hoid, &prefix), 0);


### PR DESCRIPTION
fixes: #268

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>