### PR TITLE
be/lmdb: persist unique id in db

### DIFF
--- a/src/include/zlog/backend/lmdb.h
+++ b/src/include/zlog/backend/lmdb.h
@@ -75,6 +75,7 @@ class LMDBBackend : public Backend {
 
   struct ProjectionObject {
     uint64_t epoch;
+    uint64_t unique_id;
     char prefix[128];
   };
 

--- a/src/storage/test_backend.cc
+++ b/src/storage/test_backend.cc
@@ -8,17 +8,25 @@ TEST_F(BackendTest, DeleteBeforeInit) {
   no_init_be.reset();
 }
 
+// TODO: the unique id tests should enforce that the log exists, even though an
+// implementation may not require that to generate a unique id. currently this
+// is needed for lmdb. the implementations are correct this is just a nit pick
+// on how restrictive we want to make the backend api.
 TEST_F(BackendTest, UniqueId_Args) {
   uint64_t id;
   ASSERT_EQ(backend->uniqueId("", &id), -EINVAL);
-  ASSERT_EQ(backend->uniqueId("a", &id), 0);
+  std::string hoid, prefix;
+  ASSERT_EQ(backend->CreateLog("a", "", &hoid, &prefix), 0);
+  ASSERT_EQ(backend->uniqueId(hoid, &id), 0);
 }
 
 TEST_F(BackendTest, UniqueId) {
+  std::string hoid, prefix;
+  ASSERT_EQ(backend->CreateLog("a", "", &hoid, &prefix), 0);
   std::set<uint64_t> ids;
   for (int i = 0; i < 100; i++) {
     uint64_t id;
-    int ret = backend->uniqueId("hoid", &id);
+    int ret = backend->uniqueId(hoid, &id);
     ASSERT_EQ(ret, 0);
     auto res = ids.emplace(id);
     ASSERT_TRUE(res.second);


### PR DESCRIPTION
clients must received unique ids for their secret. in the lmdb
implementation we were not persisting the ids and they always started at
zero even when re-opening a log. the result was that the client observed
observed an old view as if it was one that it created because it would
match the secret.

fixes: #300

Reported-by: Victor Sui <victorsui11@gmail.com>
Signed-off-by: Noah Watkins <noahwatkins@gmail.com>